### PR TITLE
Bugfix for isHex regex

### DIFF
--- a/Spreadsheet.cfc
+++ b/Spreadsheet.cfc
@@ -3179,7 +3179,7 @@ component accessors="true"{
 	}
 
 	private boolean function isHexColor( required string inputString ){
-		return arguments.inputString.REFindNoCase( "^##?[a-f]{6,6}$" );
+		return arguments.inputString.REFindNoCase( "^##?[0-9A-Fa-f]{6,6}$" );
 	}
 
 	private string function hexToRGB( required string hexColor ){


### PR DESCRIPTION
An error occurred when using colors like `D9E1F2` as regex rule was not accepting numbers.