### PR TITLE
Trigger formula evaluation on setCellFormula call

### DIFF
--- a/Spreadsheet.cfc
+++ b/Spreadsheet.cfc
@@ -1480,6 +1480,8 @@ component accessors="true"{
 		//Automatically create the cell if it does not exist, instead of throwing an error
 		var cell = initializeCell( arguments.workbook, arguments.row, arguments.column );
 		cell.setCellFormula( JavaCast( "string", arguments.formula ) );
+		// Retrieve the cell value to trigger formula evaluation
+		getCellValue(Arguments.workbook, arguments.row, arguments.column);
 	}
 
 	public void function setCellValue( required workbook, required value, required numeric row, required numeric column, string type ){


### PR DESCRIPTION
I've found that when using the `setCellFormula()` function with a formula that references cells with _another_ formula (e.g. calculating the total of a column comprised of price*qty cells), the formula is not evaluated. You can click in the cell and hit enter to get the calculation to work, but to evaluate before writing the spreadsheet to disk, you need to run the `formulaEvaluator`. The getCellValue() function already does this, so I've added a call to that within `setCellFormula()` and this resolves the problem for me.