### PR TITLE
sheetToArrayOfStructs throws array-index-out-of-bounds when rows have trailing blank cells

### DIFF
--- a/helpers/sheet.cfc
+++ b/helpers/sheet.cfc
@@ -204,7 +204,7 @@ component extends="base"{
 		return ArrayMap( intermediateResult.data, ( row )=>{
 			var rowAsOrderedStruct = [:];
 			ArrayEach( intermediateResult.columns, ( column, index )=>{
-				rowAsOrderedStruct[ column ] = row[ index ];
+				rowAsOrderedStruct[ column ] = ( index <= row.Len() ) ? row[ index ] : "";
 			});
 			return rowAsOrderedStruct;
 		})


### PR DESCRIPTION
When reading a spreadsheet with format="arrayOfStructs" if a data row has blank cells in the trailing columns, POI omits those cells from the row, producing a row array shorter than the header array. sheetToArrayOfStructs then throws an array-index-out-of-bounds error because it assumes every row has the same number of elements as the column headers.

See: https://github.com/cfsimplicity/spreadsheet-cfml/issues/446