### PR TITLE
Fix loop index initialization in checkArrayRow

### DIFF
--- a/objects/WriteCsv.cfc
+++ b/objects/WriteCsv.cfc
@@ -170,6 +170,7 @@ component extends="BaseCsv" accessors="true"{
 
 	private array function checkArrayRow( required array row ){
 		var totalColumns = arguments.row.Len();
+		var i = "";
 		cfloop( from=1, to=totalColumns, index="i" ){
 			var value = arguments.row[ i ];
 			if( !IsSimpleValue( value ) )


### PR DESCRIPTION
Initialize loop index variable 'i' as an empty string. (was flagged while trying to migrate to Modern Local Scope Mode for Lucee)